### PR TITLE
 Fix actions to build documentation on merge at main

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
     - dev
-    - main
   pull_request:
     branches:
     - main
@@ -61,7 +60,7 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref_name == 'main'
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
     - dev
+    - main
   pull_request:
     branches:
     - main

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,10 +1,7 @@
 name: Build, run tests and deploy GitHub Pages
-run-name: Build triggered by "${{github.event_name}}"
+run-name: Build triggered by "${{github.event.pull_request.user}}" for pull_request on branch main
 
 on:
-  push:
-    branches:
-    - dev
   pull_request:
     branches:
     - main
@@ -25,7 +22,6 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
-    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || (github.event_name == 'push')}}
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
@@ -61,7 +57,7 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true }}
+    if: ${{ github.event.pull_request.merged == true }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -25,6 +25,7 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) || (github.event_name == 'push')}}
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
@@ -81,7 +82,6 @@ jobs:
           sphinx-build documentation/source documentation/build
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
-        if: ${{github.ref == 'refs/heads/main' }}
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,5 +1,5 @@
 name: Build, run tests and deploy GitHub Pages
-run-name: Build triggered by "${{github.event.pull_request.user}}" for pull_request on branch main
+run-name: Build triggered by Pull Request ${{github.event.number}} on branch main
 
 on:
   pull_request:


### PR DESCRIPTION
Changed the actions workflow to only trigger builds and test when a PR is opened against main. Also, only deploy GitHub page if merge has been accepted. 