### PR TITLE
To matrix

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -3,6 +3,7 @@ run-name: Build triggered by Pull Request ${{github.event.number}} on branch mai
 
 on:
   pull_request:
+    types: [opened, closed]
     branches:
     - main
 
@@ -57,7 +58,7 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ github.event.pull_request.merged == true }}
+    if: github.event.pull_request.merged
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -6,7 +6,7 @@ Welcome to PauliArray's documentation.
 
 .. important::
 
-    This documentation is under construction.
+    This documentation and library are under development. If you want to open an issue or contribute, feel free to do so through the `PauliArray repository <https://github.com/algolab-quantique/pauliarray>`_
 
 This library has been developped as an **efficient manipulation toolbox** for Pauli operators.
 
@@ -14,20 +14,19 @@ This library has been developped as an **efficient manipulation toolbox** for Pa
     An indepth description and advantages showcase of PauliArray can be found in the PauliArray technical paper
     available on the `ArXiv <https://arxiv.org/abs/2405.19287>`_.
 
-
 Installation
 =============
 
-Once you have downloaded/cloned the PauliArray repository, you can install from the directory containing the :code:`pyproject.toml` file with the following command.
+Once you have downloaded/cloned the PauliArray repository, you can install from the directory containing the `pyproject.toml` file with the following command
 
 .. code::
 
     pip install .
 
-To devellop PauliArray
+To develop PauliArray
 ----------------------
 
-We recommand using `flit <https://flit.pypa.io/en/stable/>`_ to install PauliArray if you plan to devellop it and to use its symbolic link option. Again, from the directory containing the :code:`pyproject.toml` file with the following command.
+To install PauliArray with the aim of editing or developping features, we recommand using [flit](https://flit.pypa.io/en/stable/) for the installation and to use its symbolic link option. Again, from the directory containing the `pyproject.toml` file, execute the following command
 
 .. code::
 

--- a/pauliarray/pauli/weighted_pauli_array.py
+++ b/pauliarray/pauli/weighted_pauli_array.py
@@ -448,15 +448,18 @@ class WeightedPauliArray(object):
         """
         return self._paulis.is_diagonal()
 
-    def to_matrices(self) -> NDArray:
+    def to_matrices(self, sparse: bool = False) -> NDArray:
         """
         Returns the WeightedPauliArray as a numpy matrix.
+
+        Args:
+            sparse (bool): If True, matrices are returned in the CSR format
 
         Returns:
             matrices (NDArray): An ndarray of shape self.shape + (n**2, n**2).
         """
 
-        return self.weights[..., None, None] * self.paulis.to_matrices()
+        return self.weights * self.paulis.to_matrices(sparse=sparse)
 
     @classmethod
     def new(cls, shape: Tuple[int, ...], num_qubits: int) -> "WeightedPauliArray":

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -194,6 +194,14 @@ class TestOperator(unittest.TestCase):
 
         os.remove("operator.npz")
 
+    def test_to_matrix(self):
+
+        po = 0.5 * op.Operator.from_labels_and_weights(["II", "XI", "IZ", "XZ"], np.array([1, 1, 1, -1]))
+
+        expected_matrix = np.array([[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0]])
+
+        self.assertTrue(np.all(np.isclose(po.to_matrix(sparse=True).toarray(), expected_matrix)))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pauli_array.py
+++ b/tests/test_pauli_array.py
@@ -182,7 +182,7 @@ class TestPauliArray(unittest.TestCase):
 
         matrices = paulis_1.to_matrices()
 
-        expected_matricies = np.array(
+        expected_matrices = np.array(
             [
                 [
                     [0.0 + 0.0j, 1.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
@@ -199,7 +199,15 @@ class TestPauliArray(unittest.TestCase):
             ]
         )
 
-        self.assertTrue(np.all(matrices == expected_matricies))
+        for i in range(len(matrices)):
+            self.assertTrue(np.all(np.isclose(matrices[i], expected_matrices[i, :, :])))
+
+        matrices = paulis_1.to_matrices(sparse=True)
+
+        print(type(matrices[0]))
+
+        for i in range(len(matrices)):
+            self.assertTrue(np.all(np.isclose(matrices[i].toarray(), expected_matrices[i, :, :])))
 
     def test_x(self):
         paulis_basis = gen_complete_pauli_array_basis(1)

--- a/tests/test_weighted_pauli_array.py
+++ b/tests/test_weighted_pauli_array.py
@@ -108,6 +108,36 @@ class TestWeightedPauliArray(unittest.TestCase):
 
         os.remove("wpaulis.npz")
 
+    def test_to_matrices(self):
+        wpaulis_1 = wpa.WeightedPauliArray.from_labels_and_weights(["IX", "XX"], [2, 3])
+
+        matrices = wpaulis_1.to_matrices()
+
+        expected_matrices = np.array(
+            [
+                [
+                    [0.0 + 0.0j, 2.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+                    [2.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+                    [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 2.0 + 0.0j],
+                    [0.0 + 0.0j, 0.0 + 0.0j, 2.0 + 0.0j, 0.0 + 0.0j],
+                ],
+                [
+                    [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 3.0 + 0.0j],
+                    [0.0 + 0.0j, 0.0 + 0.0j, 3.0 + 0.0j, 0.0 + 0.0j],
+                    [0.0 + 0.0j, 3.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+                    [3.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+                ],
+            ]
+        )
+
+        for i in range(len(matrices)):
+            self.assertTrue(np.all(np.isclose(matrices[i], expected_matrices[i, :, :])))
+
+        matrices = wpaulis_1.to_matrices(sparse=True)
+
+        for i in range(len(matrices)):
+            self.assertTrue(np.all(np.isclose(matrices[i].toarray(), expected_matrices[i, :, :])))
+
 
 class TestWeightedPauliArrayFunc(unittest.TestCase):
     def test_concatenate(self):


### PR DESCRIPTION
Changed how to_matrix methods works
- Added the ability to produce sparse matrix
- Renamed sparse_matrix_from_zx_ints to matrix_elements_from_zx_ints
- Improved the implementation of matrix_elements_from_zx_ints
- Added associated tests
- The to_matrices now returns array of arrays or sparse arrays, instead of a multi-dimensionnal array where slices where the matrices