### PR TITLE
21 small issues

### DIFF
--- a/pauliarray/binary/bit_operations.py
+++ b/pauliarray/binary/bit_operations.py
@@ -107,24 +107,6 @@ def inv(bit_matrix: "np.ndarray[np.bool]") -> "np.ndarray[np.bool]":
     return inv_matrix.astype(bool)
 
 
-def inv2(bit_matrix: "np.ndarray[np.bool]") -> "np.ndarray[np.bool]":
-    """
-    Computes the inverse of a binary matrix. (DOES NOT ALWAYS WORK!!!)
-
-    Args:
-        bit_matrix ("np.ndarray[np.bool]"): Input binary matrix.
-
-    Returns:
-        "np.ndarray[np.bool]": Inverse of the input binary matrix.
-    """
-    assert bit_matrix.ndim == 2
-    assert bit_matrix.shape[0] == bit_matrix.shape[1]
-
-    int_inv_matrix = np.linalg.inv(bit_matrix.astype(np.uint8))
-
-    return np.mod(int_inv_matrix, 2).astype(bool)
-
-
 def strings_to_ints(bit_strings: "np.ndarray[np.bool]") -> "np.ndarray[np.int]":
     """
     Converts binary strings to integers.

--- a/pauliarray/binary/bit_operations.py
+++ b/pauliarray/binary/bit_operations.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -94,8 +96,33 @@ def inv(bit_matrix: "np.ndarray[np.bool]") -> "np.ndarray[np.bool]":
         "np.ndarray[np.bool]": Inverse of the input binary matrix.
     """
     assert bit_matrix.ndim == 2
+    assert bit_matrix.shape[0] == bit_matrix.shape[1]
 
-    return np.linalg.inv(bit_matrix.astype(np.int8)).astype(bool)
+    exp_matrix = np.concatenate((bit_matrix, np.identity(bit_matrix.shape[0], dtype=bool)), axis=1)
+
+    re_exp_matrix = row_echelon(exp_matrix)
+
+    inv_matrix = re_exp_matrix[:, bit_matrix.shape[0] :]
+
+    return inv_matrix.astype(bool)
+
+
+def inv2(bit_matrix: "np.ndarray[np.bool]") -> "np.ndarray[np.bool]":
+    """
+    Computes the inverse of a binary matrix. (DOES NOT ALWAYS WORK!!!)
+
+    Args:
+        bit_matrix ("np.ndarray[np.bool]"): Input binary matrix.
+
+    Returns:
+        "np.ndarray[np.bool]": Inverse of the input binary matrix.
+    """
+    assert bit_matrix.ndim == 2
+    assert bit_matrix.shape[0] == bit_matrix.shape[1]
+
+    int_inv_matrix = np.linalg.inv(bit_matrix.astype(np.uint8))
+
+    return np.mod(int_inv_matrix, 2).astype(bool)
 
 
 def strings_to_ints(bit_strings: "np.ndarray[np.bool]") -> "np.ndarray[np.int]":
@@ -149,6 +176,50 @@ def row_echelon(bit_matrix: "np.ndarray[np.bool]") -> "np.ndarray[np.bool]":
             k_col += 1
 
     return re_bit_matrix
+
+
+def row_echelon_with_map(bit_matrix: "np.ndarray[np.bool]") -> Tuple["np.ndarray[np.bool]", "np.ndarray[np.bool]"]:
+    """
+    Applies Gauss-Jordan elimination on a binary matrix to produce row echelon form.
+
+    Args:
+        bit_matrix ("np.ndarray[np.bool]"): Input binary matrix.
+
+    Returns:
+        "np.ndarray[np.bool]": Row echelon form of the provided matrix.
+        "np.ndarray[np.bool]": The map matrix constains the information on which lines were combined.
+    """
+    re_bit_matrix = bit_matrix.copy()
+
+    map_matrix = np.identity(bit_matrix.shape[0], dtype=bool)
+
+    n_rows = re_bit_matrix.shape[0]
+    n_cols = re_bit_matrix.shape[1]
+
+    row_range = np.arange(n_rows)
+
+    h_row = 0
+    k_col = 0
+
+    while h_row < n_rows and k_col < n_cols:
+        if np.all(re_bit_matrix[h_row:, k_col] == 0):
+            k_col += 1
+        else:
+            i_row = h_row + np.argmax(re_bit_matrix[h_row:, k_col])
+            if i_row != h_row:
+                re_bit_matrix[[i_row, h_row], :] = re_bit_matrix[[h_row, i_row], :]
+                map_matrix[[i_row, h_row], :] = map_matrix[[h_row, i_row], :]
+
+            cond_rows = np.logical_and(re_bit_matrix[:, k_col], (row_range != h_row))
+
+            re_bit_matrix[cond_rows, :] = np.logical_xor(re_bit_matrix[cond_rows, :], re_bit_matrix[h_row, :][None, :])
+
+            map_matrix[cond_rows, :] = np.logical_xor(map_matrix[cond_rows, :], map_matrix[h_row, :][None, :])
+
+            h_row += 1
+            k_col += 1
+
+    return re_bit_matrix, map_matrix
 
 
 def kernel(bit_matrix: "np.ndarray[np.bool]") -> "np.ndarray[np.bool]":
@@ -229,6 +300,28 @@ def row_space(bits: "np.ndarray[np.bool]") -> "np.ndarray[np.bool]":
     null_rows = np.all(~row_ech_bits, axis=1)
 
     return row_ech_bits[~null_rows, :]
+
+
+def row_space_with_map(bits: "np.ndarray[np.bool]") -> Tuple["np.ndarray[np.bool]", "np.ndarray[np.bool]"]:
+    """
+    Computes the row space of a binary matrix using Gauss-Jordan elimination and
+    removing the zero lines.
+
+    Args:
+        bits ("np.ndarray[np.bool]"): Input binary matrix.
+
+    Returns
+        row_ech_bits ("np.ndarray[np.bool]"): Row space of the current matrix
+        map_matrix ("np.ndarray[np.bool]"): Map matrix. The ith line of the `map_matrix` says which of the lines in `row_ech_bits` are involved in the ith line of `bits`.
+    """
+
+    row_ech_bits, inv_map_matrix = row_echelon_with_map(bits)
+
+    map_matrix = inv(inv_map_matrix)
+
+    null_rows = np.all(~row_ech_bits, axis=1)
+
+    return row_ech_bits[~null_rows, :], map_matrix[:, ~null_rows]
 
 
 def orthogonal_basis(bit_strings: "np.ndarray[np.bool]") -> "np.ndarray[np.bool]":

--- a/pauliarray/pauli/operator.py
+++ b/pauliarray/pauli/operator.py
@@ -647,6 +647,16 @@ class Operator(object):
         """
         return self.remove_small_weights(threshold).combine_repeated_terms().remove_small_weights(threshold)
 
+    def is_auto_adjoint(self) -> bool:
+        """
+        Check if the Operator is auto adjoint (hermitian)
+
+        Returns:
+            bool: True if the Operator is auto adjoint (hermitian).
+        """
+
+        return np.all(np.isclose(self.weights.imag, 0))
+
     def is_scalar(self) -> bool:
         """
         Check if the Operator is a scalar.
@@ -655,6 +665,26 @@ class Operator(object):
             bool: True if the Operator is a scalar.
         """
         return self.num_terms == 1 and np.sum(self.wpaulis[0].paulis.zx_strings) == 0
+
+    def is_zero(self, threshold=1e-12) -> bool:
+        """
+        Check if the Operator is 0 up to a threshold.
+
+        Returns:
+            bool: True if the Operator is 0 up to a threshold.
+        """
+
+        return self.is_scalar and np.sum(np.abs(self.weights)) < threshold
+
+    def is_identity(self, threshold=1e-12) -> bool:
+        """
+        Check if the Operator is 1 up to a threshold.
+
+        Returns:
+            bool: True if the Operator is 0 up to a threshold.
+        """
+
+        return self.is_scalar and np.abs(np.sum(np.abs(self.weights)) - 1) < threshold
 
     def is_unitary(self) -> bool:
         """
@@ -666,6 +696,16 @@ class Operator(object):
         self_prod_wpaulis = self.compose_operator(self.adjoint()).combine_repeated_terms().remove_small_weights()
 
         return self_prod_wpaulis.is_scalar() and np.isclose(self_prod_wpaulis.wpaulis[0].weights, 1)
+
+    def is_diagonal(self) -> bool:
+        """
+        Checks if all the Pauli strings are diagonal i.e. if all Pauli strings are I or Z.
+
+        Returns:
+            bool: True if the all the Pauli string are diagonal, False otherwise.
+        """
+
+        return np.all(self.paulis.is_diagonal())
 
     def is_clifford(self) -> bool:
         """
@@ -680,6 +720,38 @@ class Operator(object):
 
         return bool(np.all(np.isclose(sq_amp, 1 / self.num_terms))) and self.is_unitary()
 
+    def commute_with(self, other: "Operator", threshold=1e-14) -> bool:
+        """
+        Returns True if the Operator commutes an other Operator passed as parameter,
+        returns False otherwise.
+
+        Args:
+            other (Operator): The Operator to check commutation with.
+
+        Returns:
+            bool: True if the operators commutes, and false otherwise.
+        """
+
+        comm_operator = commutator(self, other).simplify(threshold=threshold)
+
+        return comm_operator.is_scalar() and (comm_operator.weights[0] == 0)
+
+    def anticommute_with(self, other: "Operator", threshold=1e-14) -> bool:
+        """
+        Returns True if the Operator commutes an other Operator passed as parameter,
+        returns False otherwise.
+
+        Args:
+            other (Operator): The Operator to check commutation with.
+
+        Returns:
+            bool: True if the operators commutes, and false otherwise.
+        """
+
+        comm_operator = anticommutator(self, other).simplify(threshold=threshold)
+
+        return comm_operator.is_scalar() and comm_operator.weights[0] == 0
+
     def trace(self) -> "np.complex":
         """
         Returns the trace of the Operator.
@@ -690,6 +762,21 @@ class Operator(object):
         paulis_traces = self.paulis.traces()
 
         return np.sum(self.weights * paulis_traces)
+
+    def to_traceless(self) -> "Operator":
+        """
+        Remove identity Pauli strings from the summation to make the operator traceless
+
+        Returns:
+            Operator: Traceless operator.
+        """
+
+        non_identity_mask = ~self.paulis.is_identity()
+
+        new_paulis = self.paulis[non_identity_mask]
+        new_weights = self.weights[non_identity_mask]
+
+        return Operator.from_paulis_and_weights(new_paulis, new_weights)
 
     def update_weights(self, new_weights):
         """

--- a/pauliarray/pauli/operator.py
+++ b/pauliarray/pauli/operator.py
@@ -958,6 +958,29 @@ class Operator(object):
         return cls(wpa.WeightedPauliArray.from_npz(filename))
 
 
+def sum(operators: List[Operator], simplify: bool = True) -> Operator:
+    """
+    Add the Operators in the list
+
+    Args:
+        operators (List[Operator]): A list of Operators
+        simplify (bool, optional): Apply simplification. Defaults to True.
+
+    Returns:
+        Operator: The sum of all Operators
+    """
+
+    if simplify:
+        new_operator = operators[0]
+        for operator in operators[1:]:
+            new_operator = new_operator.add_operator(operator)
+        return new_operator
+
+    new_wpaulis = wpa.concatenate([operator.wpaulis for operator in operators], 0)
+
+    return Operator(new_wpaulis)
+
+
 def commutator(operator_1: Operator, operator_2: Operator) -> Operator:
     r"""
     Computes the commutator

--- a/pauliarray/pauli/operator_array_type_1.py
+++ b/pauliarray/pauli/operator_array_type_1.py
@@ -281,6 +281,18 @@ class OperatorArrayType1(object):
 
         return op.Operator(self.wpaulis[idx])
 
+    def traces(self) -> "np.ndarray[np.complex]":
+        """
+        Return the traces of the Operators.
+
+        Returns:
+            "np.ndarray[np.complex]": Traces of the Operators
+        """
+
+        paulis_traces = self.paulis.traces()
+
+        return np.sum(self.weights * paulis_traces, axis=-1)
+
     def inspect(self) -> str:
         """
         Creates a string describing the operator array.

--- a/pauliarray/pauli/operator_array_type_1.py
+++ b/pauliarray/pauli/operator_array_type_1.py
@@ -629,6 +629,19 @@ class OperatorArrayType1(object):
         """
         return cls(cls._operator_ndarray_to_wpaulis(operators))
 
+    @classmethod
+    def from_operator(cls, operator: op.Operator) -> Self:
+        """
+        Constructs an OperatorArrayType1 instance from a single operator.
+
+        Args:
+            operator (op.Operator): An operator object.
+
+        Returns:
+            OperatorArrayType1: A new OperatorArrayType1 instance.
+        """
+        return cls.from_operator_ndarray(np.array([operator], dtype=op.Operator))
+
     @staticmethod
     def _operator_ndarray_to_wpaulis(operators) -> wpa.WeightedPauliArray:
         """

--- a/pauliarray/pauli/operator_array_type_2.py
+++ b/pauliarray/pauli/operator_array_type_2.py
@@ -421,6 +421,18 @@ class OperatorArrayType2(object):
 
         return op.Operator.from_paulis_and_weights(paulis, weights)
 
+    def traces(self) -> "np.ndarray[np.complex]":
+        """
+        Return the traces of the Operators.
+
+        Returns:
+            "np.ndarray[np.complex]": Traces of the Operators
+        """
+
+        basis_traces = self.basis_paulis.traces()
+
+        return np.einsum("...i,i->...", self.weights, basis_traces)
+
     def sum(self, axis: Union[Tuple[int, ...], None] = None) -> op.Operator:
         """
         Sums the operators along the specified axis.

--- a/pauliarray/pauli/pauli_array.py
+++ b/pauliarray/pauli/pauli_array.py
@@ -531,11 +531,13 @@ class PauliArray(object):
             NDArray: Element [idx,j] = True if generator j is used to construct self[idx]
         """
 
-        generators = self.generators()
+        generator_zx_strings, composition_map = bitops.row_space_with_map(self.flatten().zx_strings)
 
-        combinaison_map = np.any(self.zx_strings[..., None, :] * generators.zx_strings[None, :, :], axis=-1)
+        generators = PauliArray(
+            generator_zx_strings[..., : self.num_qubits], generator_zx_strings[..., self.num_qubits :]
+        )
 
-        return generators, combinaison_map
+        return generators, composition_map
 
     def inspect(self) -> str:
         """
@@ -947,7 +949,7 @@ class PauliArray(object):
 
     @staticmethod
     def labels_to_z_strings_x_strings(
-        labels: Union[list[str], "np.ndarray[np.str]"]
+        labels: Union[list[str], "np.ndarray[np.str]"],
     ) -> Tuple["np.ndarray[np.bool]", "np.ndarray[np.bool]"]:
         """
         Returns z strings and x strings created from labels.

--- a/pauliarray/pauli/weighted_pauli_array.py
+++ b/pauliarray/pauli/weighted_pauli_array.py
@@ -254,6 +254,16 @@ class WeightedPauliArray(object):
     def bitwise_commute_with(self, other: "WeightedPauliArray") -> "np.ndarray[np.bool]":
         return self.paulis.bitwise_commute_with(other.paulis)
 
+    def traces(self) -> NDArray:
+        """
+        Return the traces of the Weighted Pauli Strings which are 2^n * weight if Identity and 0 otherwise.
+
+        Returns:
+            "np.ndarray[np.int]": Traces of the Pauli Strings
+        """
+
+        return self.weights * self.paulis.traces()
+
     def inspect(self) -> str:
         if self.ndim == 0:
             return "Empty PauliArray"

--- a/tests/test_bits_operations.py
+++ b/tests/test_bits_operations.py
@@ -58,23 +58,114 @@ class TestBitsOperations(unittest.TestCase):
 
         self.assertTrue(kernel_bits_2.shape[0] == 0)
 
+    def test_inv(self):
+
+        invertible_matrix = bits = np.array(
+            [
+                [1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1],
+                [1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0],
+                [0, 0, 1, 0, 1, 1, 0, 0, 1, 0, 1, 1],
+                [1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
+                [1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0],
+                [0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0],
+                [0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0],
+                [0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0],
+                [1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0],
+                [0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0],
+                [0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+            ],
+            dtype=bool,
+        )
+        size = bits.shape[0]
+
+        assert bitops.rank(invertible_matrix) == size
+
+        inv_matrix = bitops.inv(invertible_matrix)
+
+        res = np.mod(inv_matrix.astype(int) @ invertible_matrix.astype(int), 2)
+
+        assert np.all(res == np.identity(size, dtype=bool))
+
+    def test_inv_random(self):
+
+        size = 12
+        random_mat = np.tril(np.random.choice([0, 1], p=(0.5, 0.5), size=(size, size)).astype(bool))
+
+        invertible_matrix = np.logical_or(random_mat, np.identity(size, dtype=bool))
+
+        order = np.arange(size)
+        np.random.shuffle(order)
+        invertible_matrix = invertible_matrix[order, :][:, order]
+
+        assert bitops.rank(invertible_matrix) == size
+
+        inv_matrix = bitops.inv(invertible_matrix)
+
+        res = np.mod(inv_matrix.astype(int) @ invertible_matrix.astype(int), 2)
+
+        assert np.all(res == np.identity(size, dtype=bool))
+
     def test_row_echelon(self):
 
         bits = np.array(
             [
-                [0, 0, 0, 0, 1, 0, 0, 0],
-                [0, 0, 0, 0, 0, 1, 0, 1],
-                [0, 0, 0, 0, 0, 0, 1, 0],
-                [1, 0, 0, 1, 0, 0, 0, 0],
-                [0, 1, 0, 1, 0, 0, 0, 0],
-                [0, 0, 1, 1, 0, 0, 0, 0],
+                [1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1],
+                [1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0],
+                [0, 0, 1, 0, 1, 1, 0, 0, 1, 0, 1, 1],
+                [1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
+                [1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0],
+                [0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0],
+                [0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0],
+                [0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0],
+                [1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0],
+                [0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0],
+                [0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
             ],
-            dtype=np.bool_,
+            dtype=bool,
         )
+
+        size = bits.shape[0]
 
         re_bits = bitops.row_echelon(bits)
 
-        # TODO validate test
+        assert np.all(re_bits == np.identity(size, dtype=bool))
+
+    def test_row_echelon_random(self):
+
+        size = 12
+        random_mat = np.tril(np.random.choice([0, 1], p=(0.5, 0.5), size=(size, size)).astype(bool))
+
+        bits = np.logical_or(random_mat, np.identity(size, dtype=bool))
+
+        re_bits = bitops.row_echelon(bits)
+
+        assert np.all(re_bits == np.identity(size, dtype=bool))
+
+    def test_row_echelon_with_map(self):
+
+        size = 12
+        random_mat = np.tril(np.random.choice([0, 1], p=(0.5, 0.5), size=(size, size)).astype(bool))
+
+        bits = np.logical_or(random_mat, np.identity(size, dtype=bool))
+
+        re_bits, bit_map = bitops.row_echelon_with_map(bits)
+
+        res = np.mod(bits.astype(int) @ bit_map.astype(int), 2)
+
+        assert np.all(res == np.identity(size, dtype=bool))
+
+    def test_row_space_with_map(self):
+
+        bits = np.random.choice([0, 1], p=(0.5, 0.5), size=(12, 15)).astype(bool)
+
+        re_bits, bit_map = bitops.row_space_with_map(bits)
+
+        re_re_bits = bit_map.astype(int) @ re_bits.astype(int)
+        mod_re_re_bits = np.mod(re_re_bits, 2)
+
+        assert np.all(mod_re_re_bits == bits)
 
     def test_intersection(self):
 

--- a/tests/test_pauli_array.py
+++ b/tests/test_pauli_array.py
@@ -79,9 +79,8 @@ class TestPauliArray(unittest.TestCase):
         generators = paulis_1.generators()
 
     def test_generators_with_map(self):
-        a_paulis = pa.PauliArray.from_labels(
-            ["II", "IX", "IY", "IZ", "XI", "XX", "XY", "XZ", "YI", "YX", "YY", "YZ", "ZI", "ZX", "ZY", "ZZ"]
-        )
+
+        a_paulis = pa.PauliArray.random((24,), 4)
 
         generators, combinaison_map = a_paulis.generators_with_map()
 


### PR DESCRIPTION
- Updated `bit_operation`. The `inv` function based on `numpy.linalg.inv` was failing for some matrices. The new one is based on row eahcelin. It is slower but more reliable.
- New function `row_echelon_with_map` and `row_space_with_map` return a `mapping_matrix` which represents the line operation performed.
- This allows to implement `PauliArray.generators_with_map`.
- Added `trace` and `traces` method to relevant classes.
- Added `is_auto_adjoint`, `is_zero`, `is_diagonal`, etc. to `Operator`. Also added `commute_with`, `anticommute_with` and `to_traceless`.
- Added a convenient `operator.sum` function to sum a list of `Operator`s.